### PR TITLE
Removed deprecated function utcnow

### DIFF
--- a/i2i/router.py
+++ b/i2i/router.py
@@ -11,7 +11,7 @@ Routes queries to the optimal model(s) based on:
 from enum import Enum
 from typing import Optional, List, Dict, Any, Tuple
 from pydantic import BaseModel, Field
-from datetime import datetime
+from datetime import datetime, timezone
 import asyncio
 import json
 import os
@@ -1490,7 +1490,7 @@ class ModelRouter:
     def _log_performance(self, result: RoutingResult):
         """Log performance for future optimization."""
         log_entry = {
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
             "task_type": result.decision.detected_task.value,
             "strategy": result.decision.strategy_used.value,
             "models_used": result.decision.selected_models,

--- a/i2i/schema.py
+++ b/i2i/schema.py
@@ -8,7 +8,7 @@ including message types, response structures, and classification enums.
 from enum import Enum
 from typing import Optional, List, Dict, Any
 from pydantic import BaseModel, Field
-from datetime import datetime
+from datetime import datetime, timezone
 import uuid
 
 
@@ -63,7 +63,7 @@ class Message(BaseModel):
     recipient: Optional[str] = None    # Target model (None = broadcast)
     context: Optional[List["Message"]] = None  # Previous messages in thread
     metadata: Dict[str, Any] = Field(default_factory=dict)
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     # For challenge/verify messages
     target_message_id: Optional[str] = None  # Message being challenged/verified

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -2,7 +2,7 @@
 
 import pytest
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from i2i.schema import (
     Message,
@@ -99,9 +99,9 @@ class TestMessage:
 
     def test_message_auto_generates_timestamp(self):
         """Message should auto-generate a timestamp."""
-        before = datetime.utcnow()
+        before = datetime.now(timezone.utc)
         msg = Message(type=MessageType.QUERY, content="Test")
-        after = datetime.utcnow()
+        after = datetime.now(timezone.utc)
         assert before <= msg.timestamp <= after
 
     def test_message_with_all_fields(self):


### PR DESCRIPTION
Fixed deprecated (as of python 3.12) utcnow syntax.

DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC). after = datetime.utcnow()